### PR TITLE
Feature/add cargo doc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,45 @@
+name: Rust
+
+on:
+  push:
+    branches: ["feature/add-cargo-doc"]
+  pull_request:
+    branches: ["feature/add-cargo-doc"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+  #    - name: Run tests
+  #      run: cargo test --verbose
+  doc:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' || github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run doc
+        run: cargo doc --no-deps
+      - name: Deploy
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: target/doc
+  deploy:
+    needs: doc
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ pub mod EndPont {
     pub static EP1: u8 = 1;
 }
 
+/// Initializes the USB device with the specified vid, pid, and b_interface_number.  
+/// It is recommended to set b_interface_number to 1.
 pub fn init_usb_handle(vendor_id: u16, product_id: u16, b_interface_number: u8) -> Result<DeviceHandle<GlobalContext>, rusb::Error>{
     let handle = loop {
         match open_device_with_vid_pid(vendor_id, product_id) {
@@ -40,6 +42,8 @@ pub fn init_usb_handle(vendor_id: u16, product_id: u16, b_interface_number: u8) 
     return Ok(handle);
 }
 
+/// Sends an emergency signal to the drobo CAN device (for example, MD, SD, etc.)   
+/// It's not possible to confirm whether the signal was sent properly, and this function always returns nothing.
 pub fn send_emergency(handle_: &DeviceHandle<GlobalContext>){
     let send_buf: [u8; 8] = [
         IdType::EMMERGENCY,

--- a/src/md.rs
+++ b/src/md.rs
@@ -37,6 +37,26 @@ fn count_to_rpm(rpm: i16) -> i16 {
     return rpm.round() as i16
 }
 
+/// Sends a command to set the PWM duty cycle on the specified MD device.
+/// ## Example
+/// Sample code to rotate a motor connected to the MD at address 0x00 at a PWM duty cycle of 1000.  
+/// This sample code retrieves information such as the rotation speed after running the motor.
+/// ```rust
+/// use motor_lib::{init_usb_handle, md, send_emergency};
+/// fn main() {
+///    let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
+///    let return_status = 
+///    loop {
+///         match md::send_pwm(&handle, 0x00, 1000) {
+///             Ok(t) => {
+///                 break t;
+///             },
+///             Err(e) => {}
+///         }
+///    }
+///    println!("{:?}", return_status);
+/// }
+/// ```
 pub fn send_pwm(handle_: &DeviceHandle<GlobalContext>, address_: u8, power_: i16) -> Result<MdStatus, Error>{
     let send_buf: [u8; 8] = [
         address_,
@@ -52,6 +72,17 @@ pub fn send_pwm(handle_: &DeviceHandle<GlobalContext>, address_: u8, power_: i16
     return receive_status(handle_, address_)
 }
 
+/// Sends a command to set the rotation speed on the specified MD device.
+/// ## Example
+/// Sample code to rotate a motor connected to the MD at address 0x00 at 100 rpm.
+/// ```rust
+/// use motor_lib::{init_usb_handle, md, send_emergency};
+/// fn main() -> Result<(), motor_lib::Error> {
+///    let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
+///    md::send_speed(&handle, 0x00, 100)?;
+///    Ok(())
+/// }
+/// ```
 pub fn send_speed(handle_: &DeviceHandle<GlobalContext>, address_: u8, velocity_: i16) -> Result<MdStatus, Error>{
     if velocity_ == 0 {
         send_pwm(handle_, address_, 0)?;
@@ -88,6 +119,7 @@ pub fn send_angle(handle_: &DeviceHandle<GlobalContext>, address_: u8, angle_: i
     return receive_status(handle_, address_)
 }
 
+/// Sends a command to set the duty cycle on before and after pressing the limit switch.
 pub fn send_limsw(handle_: &DeviceHandle<GlobalContext>, address_: u8, port_: u8, power_: i16, after_power_: i16) -> Result<MdStatus, Error>{
     let send_buf: [u8; 8] = [
         address_,
@@ -103,9 +135,24 @@ pub fn send_limsw(handle_: &DeviceHandle<GlobalContext>, address_: u8, port_: u8
     return receive_status(handle_, address_)
 }
 
+/// Receive a data from the specified MD device.
+/// ## Example
+/// Sample code to rotate a motor at 100 rpm and continuously retrieve rotation speed data.
+/// ```rust
+/// use motor_lib::{init_usb_handle, md, send_emergency};
+/// fn main() -> Result<(), motor_lib::Error> {
+///    let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
+///    md::send_speed(&handle, 0x00, 100)?;
+///    loop {
+///        let status = md::receive_status(&handle, 0x00)?;
+///        println!("{:?}", status);
+///    }
+///    Ok(())
+/// }
+/// ```
 #[allow(unused_variables)]
 pub fn receive_status(handle_: &DeviceHandle<GlobalContext>, address_: u8) -> Result<MdStatus, Error>{
-    let mut receive_buf = [0;8]; // MD側がデータ返送に対応するまでの仮実装
+    let mut receive_buf = [0;8];
     loop {
         handle_.read_bulk(LIBUSB_ENDPOINT_IN | EndPont::EP1, &mut receive_buf, Duration::from_millis(5000)).unwrap();
         if address_ == receive_buf[0] {
@@ -121,53 +168,5 @@ pub fn receive_status(handle_: &DeviceHandle<GlobalContext>, address_: u8) -> Re
                 }
             });
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{thread, time::Duration};
-
-    use crate::{init_usb_handle, md, send_emergency};
-
-    #[test]
-    fn motor_rotation() {
-        let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
-        // エラーハンドリング
-        let return_status = 
-            loop {
-                match md::send_speed(&handle, 0x00, 400) {
-                    Ok(t) => {
-                        break t
-                    },
-                    Err(_) => {
-                        // 何らかのエラー処理
-                    }
-                };
-            };
-        println!("{:?}", return_status);
-        loop {
-            let return_status = md::receive_status(&handle, 0x00).unwrap();
-            println!("{:?}", return_status);
-        }
-    }
-    #[test]
-    fn omni_control_test() {
-        let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
-        // エラーハンドリング
-        for i in 0..500 {
-            println!("{i}");
-            let _ = md::send_speed(&handle, 0x00, i).unwrap();
-            let _ = md::send_speed(&handle, 0x01, i).unwrap();
-            let return_status = md::send_speed(&handle, 0x02, i).unwrap();
-            println!("{:?}", return_status);
-            thread::sleep(Duration::from_millis(100));
-        }
-        send_emergency(&handle);
-    }
-    #[test]
-    fn stop_all() {
-        let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
-        send_emergency(&handle);
     }
 }


### PR DESCRIPTION
## 概要
`cargo doc`コマンドを用いたドキュメント生成を試してみました．  
Rustのコードの中にドキュメントやサンプルコードを書く形になります．  
[https://nityc-d-robo.github.io/motor_lib/motor_lib/index.html](https://nityc-d-robo.github.io/motor_lib/motor_lib/index.html)にアクセスすることで閲覧できます．とりあえずlib.rsとmd.rsについて真面目に書いてみました．  
## どんなところを見てほしい？
莫大な量のコメントがコードの見やすさにどう影響するか，ドキュメントの見やすさはどうかといった点について他の人の意見が聞きたいので，積極的にコメントしてほしいです．
## 具体的に何を変更した？
* `cargo doc`でドキュメントが生成されるようなコメントを書きました．
* rust.ymlにGitHub Actionsのworkflowを書きました．pushするたびに上記URLのドキュメントが更新されます．
  * ついでに，最低限ビルドが通るかどうかを見るようにしてあります．
    * テストコードを書けばもっと堅牢になるんでしょうね
* md.rsに書いてあったサンプルコードとしての[test]を消しました．
  * これはバイナリクレートでやるべきだと思ったためです．これがマージされたら(リジェクトされたら？)書きます． 
## TODO
(マージするなら)マージした後でrust.ymlの最初のブランチ名を指定するところをdevelopにしないといけませんね．これはdevelop直コミットでいいと思います．