### PR TITLE
usbデバイスの抽象化を実装

### DIFF
--- a/src/blmd.rs
+++ b/src/blmd.rs
@@ -23,7 +23,7 @@ pub fn send_velocity(
     pid_: &mut VelPid,
     controller_id_: u8,
     velocity_: i16,
-) -> Result<BlMdStatus, usb::USBError> {
+) -> Result<BlMdStatus, crate::USBError> {
     let status = match receive_status(handle_, controller_id_) {
         Ok(s) => s,
         Err(e) => return Err(e),
@@ -41,7 +41,7 @@ pub fn send_current(
     handle_: &impl usb::USBHandleTrait,
     controller_id_: u8,
     current_: i16,
-) -> Result<BlMdStatus, usb::USBError> {
+) -> Result<BlMdStatus, crate::USBError> {
     let send_buf: [u8; 8] = [
         0x30,
         0,
@@ -61,7 +61,7 @@ pub fn send_current(
 pub fn receive_status(
     handle_: &impl usb::USBHandleTrait,
     controller_id_: u8,
-) -> Result<BlMdStatus, usb::USBError> {
+) -> Result<BlMdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];
     loop {
         match handle_.read_bulk(&mut receive_buf, Duration::from_millis(5000)) {

--- a/src/blmd.rs
+++ b/src/blmd.rs
@@ -19,7 +19,7 @@ pub struct BlMdStatus {
 }
 
 pub fn send_velocity(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     pid_: &mut VelPid,
     controller_id_: u8,
     velocity_: i16,
@@ -38,7 +38,7 @@ pub fn send_velocity(
 }
 
 pub fn send_current(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     controller_id_: u8,
     current_: i16,
 ) -> Result<BlMdStatus, crate::USBError> {
@@ -59,7 +59,7 @@ pub fn send_current(
 }
 
 pub fn receive_status(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     controller_id_: u8,
 ) -> Result<BlMdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];

--- a/src/blmd.rs
+++ b/src/blmd.rs
@@ -1,11 +1,8 @@
-use std::time::Duration;
-use rusb::{DeviceHandle, GlobalContext, constants::{LIBUSB_ENDPOINT_IN, LIBUSB_ENDPOINT_OUT}, Error};
+use crate::usb;
 use advanced_pid::{prelude::*, VelPid};
+use std::time::Duration;
 
-use crate::EndPont;
-
-#[allow(non_snake_case)]
-pub mod Mode {
+pub mod mode {
     pub const INIT: u8 = 0;
     pub const STATUS: u8 = 1;
     pub const CURRENT: u8 = 2;
@@ -21,7 +18,12 @@ pub struct BlMdStatus {
     pub current: i16,
 }
 
-pub fn send_velocity(handle_: &DeviceHandle<GlobalContext>, pid_: &mut VelPid, controller_id_: u8, velocity_: i16) -> Result<BlMdStatus, Error>{
+pub fn send_velocity(
+    handle_: &impl usb::USBHandleTrait,
+    pid_: &mut VelPid,
+    controller_id_: u8,
+    velocity_: i16,
+) -> Result<BlMdStatus, usb::USBError> {
     let status = match receive_status(handle_, controller_id_) {
         Ok(s) => s,
         Err(e) => return Err(e),
@@ -29,13 +31,17 @@ pub fn send_velocity(handle_: &DeviceHandle<GlobalContext>, pid_: &mut VelPid, c
     let actual = status.speed;
     let output = pid_.update(velocity_ as f32, actual as f32, 0.3) as i16; // 制御周期100Hz
     let return_status = send_current(handle_, controller_id_, output);
-    if cfg!(test){
+    if cfg!(test) {
         println!("{},{},{}", actual, output, status.speed);
     }
     return return_status;
 }
 
-pub fn send_current(handle_: &DeviceHandle<GlobalContext>, controller_id_: u8, current_: i16) -> Result<BlMdStatus, Error>{
+pub fn send_current(
+    handle_: &impl usb::USBHandleTrait,
+    controller_id_: u8,
+    current_: i16,
+) -> Result<BlMdStatus, usb::USBError> {
     let send_buf: [u8; 8] = [
         0x30,
         0,
@@ -44,68 +50,32 @@ pub fn send_current(handle_: &DeviceHandle<GlobalContext>, controller_id_: u8, c
         (current_ & 0xff) as u8,
         0,
         0,
-        0
+        0,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000)).unwrap();
-    return receive_status(handle_, controller_id_)
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(5000))
+        .unwrap();
+    return receive_status(handle_, controller_id_);
 }
 
-pub fn receive_status(handle_: &DeviceHandle<GlobalContext>, controller_id_: u8) -> Result<BlMdStatus, Error>{
-    let mut receive_buf = [0;8];
+pub fn receive_status(
+    handle_: &impl usb::USBHandleTrait,
+    controller_id_: u8,
+) -> Result<BlMdStatus, usb::USBError> {
+    let mut receive_buf = [0; 8];
     loop {
-        match handle_.read_bulk(LIBUSB_ENDPOINT_IN | EndPont::EP1, &mut receive_buf, Duration::from_millis(5000)){
-            Ok(_) => {},
+        match handle_.read_bulk(&mut receive_buf, Duration::from_millis(5000)) {
+            Ok(_) => {}
             Err(e) => return Err(e),
         }
         let received_stdid = (receive_buf[0] as u16) << 8 | (receive_buf[1] as u16);
-        if received_stdid == (0x200 + (controller_id_ as u16)){
-            return Ok(BlMdStatus{
+        if received_stdid == (0x200 + (controller_id_ as u16)) {
+            return Ok(BlMdStatus {
                 std_id: received_stdid,
                 angle: ((receive_buf[2] as i16) << 8 | (receive_buf[3] as i16)),
                 speed: ((receive_buf[4] as i16) << 8 | (receive_buf[5] as i16)),
                 current: ((receive_buf[6] as i16) << 8 | (receive_buf[7] as i16)),
-            })
+            });
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{init_usb_handle, send_emergency, blmd};
-
-    use advanced_pid::{prelude::*, PidConfig, VelPid};
-    use std::{time::Duration, thread::sleep};
-
-    #[test]
-    fn motor_rotation() {
-        let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
-        // エラーハンドリング
-        let return_status = 
-            loop {
-                match blmd::send_current(&handle, 1, 1000) {
-                    Ok(t) => {
-                        // エラー処理解除
-                        break t
-                    },
-                    Err(_) => {
-                        // 何らかのエラー処理
-                    }
-                };
-            };
-        println!("power: 1000, {:?}", return_status.current);
-        sleep(Duration::from_millis(10));
-        send_emergency(&handle);
-    }
-    
-    #[test]
-    fn speed_pid() {
-        let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
-        let config = PidConfig::new(1.0, 0.1, 0.1).with_limits(-16384.0, 16384.0);
-        let mut pid = VelPid::new(config);
-        for _i in (0..=100).step_by(1){
-            blmd::send_velocity(&handle, &mut pid, 2, 500).unwrap();
-            sleep(Duration::from_millis(10));
-        }
-        send_emergency(&handle);
     }
 }

--- a/src/blmd.rs
+++ b/src/blmd.rs
@@ -19,7 +19,7 @@ pub struct BlMdStatus {
 }
 
 pub fn send_velocity(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     pid_: &mut VelPid,
     controller_id_: u8,
     velocity_: i16,
@@ -38,7 +38,7 @@ pub fn send_velocity(
 }
 
 pub fn send_current(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     controller_id_: u8,
     current_: i16,
 ) -> Result<BlMdStatus, crate::USBError> {
@@ -59,7 +59,7 @@ pub fn send_current(
 }
 
 pub fn receive_status(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     controller_id_: u8,
 ) -> Result<BlMdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub enum USBError {
 
 /// Sends an emergency signal to the drobo CAN device (for example, MD, SD, etc.)   
 /// It's not possible to confirm whether the signal was sent properly, and this function always returns nothing.
-pub fn send_emergency(handle_: &impl usb::USBHandleTrait) {
+pub fn send_emergency(handle_: &mut impl usb::USBHandleTrait) {
     let send_buf: [u8; 8] = [
         device_type::EMMERGENCY,
         device_type::MASTER,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub enum USBError {
 
 /// Sends an emergency signal to the drobo CAN device (for example, MD, SD, etc.)   
 /// It's not possible to confirm whether the signal was sent properly, and this function always returns nothing.
-pub fn send_emergency(handle_: &mut impl usb::USBHandleTrait) {
+pub fn send_emergency(handle_: &impl usb::USBHandleTrait) {
     let send_buf: [u8; 8] = [
         device_type::EMMERGENCY,
         device_type::MASTER,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,12 @@ pub mod device_type {
     pub const EMMERGENCY: u8 = 0xf0;
 }
 
+pub struct USBHandle;
+#[derive(Debug)]
+pub enum USBError {
+    RUsbError(rusb::Error),
+}
+
 /// Sends an emergency signal to the drobo CAN device (for example, MD, SD, etc.)   
 /// It's not possible to confirm whether the signal was sent properly, and this function always returns nothing.
 pub fn send_emergency(handle_: &impl usb::USBHandleTrait) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,14 @@ pub enum USBError {
 
 /// Sends an emergency signal to the drobo CAN device (for example, MD, SD, etc.)   
 /// It's not possible to confirm whether the signal was sent properly, and this function always returns nothing.
+/// ## Example
+/// ```rust
+/// use motor_lib::{USBHandle, send_emergency};
+/// fn main() {
+///     let handle = USBHandle;
+///     send_emergency(&handle);
+/// }
+/// ```
 pub fn send_emergency(handle_: &impl usb::USBHandleTrait) {
     let send_buf: [u8; 8] = [
         device_type::EMMERGENCY,

--- a/src/md.rs
+++ b/src/md.rs
@@ -47,7 +47,7 @@ pub struct MdStatus {
 /// }
 /// ```
 pub fn send_pwm(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
     power_: i16,
 ) -> Result<MdStatus, crate::USBError> {
@@ -79,7 +79,7 @@ pub fn send_pwm(
 ///     Ok(())
 /// ```
 pub fn send_speed(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
     velocity_: i16,
 ) -> Result<MdStatus, crate::USBError> {
@@ -102,7 +102,7 @@ pub fn send_speed(
 }
 
 pub fn send_angle(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
     angle_: i16,
 ) -> Result<MdStatus, crate::USBError> {
@@ -125,7 +125,7 @@ pub fn send_angle(
 
 /// Sends a command to set the duty cycle on before and after pressing the limit switch.
 pub fn send_limsw(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
     port_: u8,
     power_: i16,
@@ -164,7 +164,7 @@ pub fn send_limsw(
 /// }
 /// ```
 pub fn receive_status(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
 ) -> Result<MdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];

--- a/src/md.rs
+++ b/src/md.rs
@@ -47,7 +47,7 @@ pub struct MdStatus {
 /// }
 /// ```
 pub fn send_pwm(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
     power_: i16,
 ) -> Result<MdStatus, crate::USBError> {
@@ -79,7 +79,7 @@ pub fn send_pwm(
 ///     Ok(())
 /// ```
 pub fn send_speed(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
     velocity_: i16,
 ) -> Result<MdStatus, crate::USBError> {
@@ -102,7 +102,7 @@ pub fn send_speed(
 }
 
 pub fn send_angle(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
     angle_: i16,
 ) -> Result<MdStatus, crate::USBError> {
@@ -125,7 +125,7 @@ pub fn send_angle(
 
 /// Sends a command to set the duty cycle on before and after pressing the limit switch.
 pub fn send_limsw(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
     port_: u8,
     power_: i16,
@@ -164,7 +164,7 @@ pub fn send_limsw(
 /// }
 /// ```
 pub fn receive_status(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
 ) -> Result<MdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];

--- a/src/md.rs
+++ b/src/md.rs
@@ -77,6 +77,7 @@ pub fn send_pwm(
 ///     let handle = USBHandle;
 ///     md::send_speed(&handle, 0x00, 100)?;
 ///     Ok(())
+/// }
 /// ```
 pub fn send_speed(
     handle_: &impl usb::USBHandleTrait,

--- a/src/md.rs
+++ b/src/md.rs
@@ -1,10 +1,8 @@
 use std::time::Duration;
-use rusb::{constants::{LIBUSB_ENDPOINT_IN, LIBUSB_ENDPOINT_OUT}, DeviceHandle, Error, GlobalContext};
 
-use crate::{IdType, EndPont};
+use crate::{device_type, usb};
 
-#[allow(non_snake_case)]
-pub mod Mode {
+pub mod mode {
     pub const INIT: u8 = 0;
     pub const STATUS: u8 = 1;
     pub const PWM: u8 = 2;
@@ -30,11 +28,11 @@ pub struct MdStatus {
 
 fn rpm_to_count(rpm: i16) -> i16 {
     let count = 8192.0 * (rpm as f64) / (12.0 * 1000.0);
-    return count.round() as i16
+    return count.round() as i16;
 }
 fn count_to_rpm(rpm: i16) -> i16 {
     let rpm = (12.0 * 1000.0 * rpm as f64) / 8192.0;
-    return rpm.round() as i16
+    return rpm.round() as i16;
 }
 
 /// Sends a command to set the PWM duty cycle on the specified MD device.
@@ -45,7 +43,7 @@ fn count_to_rpm(rpm: i16) -> i16 {
 /// use motor_lib::{init_usb_handle, md, send_emergency};
 /// fn main() {
 ///    let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
-///    let return_status = 
+///    let return_status =
 ///    loop {
 ///         match md::send_pwm(&handle, 0x00, 1000) {
 ///             Ok(t) => {
@@ -57,19 +55,25 @@ fn count_to_rpm(rpm: i16) -> i16 {
 ///    println!("{:?}", return_status);
 /// }
 /// ```
-pub fn send_pwm(handle_: &DeviceHandle<GlobalContext>, address_: u8, power_: i16) -> Result<MdStatus, Error>{
+pub fn send_pwm(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+    power_: i16,
+) -> Result<MdStatus, usb::USBError> {
     let send_buf: [u8; 8] = [
         address_,
-        IdType::MASTER,
-        Mode::PWM,
+        device_type::MASTER,
+        mode::PWM,
         0,
         ((power_ >> 8) & 0xff) as u8,
         (power_ & 0xff) as u8,
         0,
-        0
+        0,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000)).unwrap();
-    return receive_status(handle_, address_)
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(5000))
+        .unwrap();
+    return receive_status(handle_, address_);
 }
 
 /// Sends a command to set the rotation speed on the specified MD device.
@@ -77,62 +81,80 @@ pub fn send_pwm(handle_: &DeviceHandle<GlobalContext>, address_: u8, power_: i16
 /// Sample code to rotate a motor connected to the MD at address 0x00 at 100 rpm.
 /// ```rust
 /// use motor_lib::{init_usb_handle, md, send_emergency};
-/// fn main() -> Result<(), motor_lib::Error> {
+/// fn main() -> Result<(), motor_lib::usb::USBError> {
 ///    let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
 ///    md::send_speed(&handle, 0x00, 100)?;
 ///    Ok(())
 /// }
 /// ```
-pub fn send_speed(handle_: &DeviceHandle<GlobalContext>, address_: u8, velocity_: i16) -> Result<MdStatus, Error>{
+pub fn send_speed(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+    velocity_: i16,
+) -> Result<MdStatus, usb::USBError> {
     if velocity_ == 0 {
         send_pwm(handle_, address_, 0)?;
     } else {
-    let count = rpm_to_count(velocity_);
-    let send_buf: [u8; 8] = [
-        address_,
-        IdType::MASTER,
-        Mode::SPEED,
-        0,
-        ((count >> 8) & 0xff) as u8,
-        (count & 0xff) as u8,
-        0,
-        0
-    ];
-        handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000))?;
+        let count = rpm_to_count(velocity_);
+        let send_buf: [u8; 8] = [
+            address_,
+            device_type::MASTER,
+            mode::SPEED,
+            0,
+            ((count >> 8) & 0xff) as u8,
+            (count & 0xff) as u8,
+            0,
+            0,
+        ];
+        handle_.write_bulk(&send_buf, Duration::from_millis(5000))?;
     }
-    return receive_status(handle_, address_)
+    return receive_status(handle_, address_);
 }
 
-pub fn send_angle(handle_: &DeviceHandle<GlobalContext>, address_: u8, angle_: i16) -> Result<MdStatus, Error>{
+pub fn send_angle(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+    angle_: i16,
+) -> Result<MdStatus, usb::USBError> {
     let angle_abs = angle_.abs();
     let send_buf: [u8; 8] = [
         address_,
-        IdType::MASTER,
-        Mode::SPEED,
-        if angle_ >= 0 {0} else {1},
+        device_type::MASTER,
+        mode::SPEED,
+        if angle_ >= 0 { 0 } else { 1 },
         ((angle_abs >> 8) & 0xff) as u8,
         (angle_abs & 0xff) as u8,
         0,
-        0
+        0,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000)).unwrap();
-    return receive_status(handle_, address_)
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(5000))
+        .unwrap();
+    return receive_status(handle_, address_);
 }
 
 /// Sends a command to set the duty cycle on before and after pressing the limit switch.
-pub fn send_limsw(handle_: &DeviceHandle<GlobalContext>, address_: u8, port_: u8, power_: i16, after_power_: i16) -> Result<MdStatus, Error>{
+pub fn send_limsw(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+    port_: u8,
+    power_: i16,
+    after_power_: i16,
+) -> Result<MdStatus, usb::USBError> {
     let send_buf: [u8; 8] = [
         address_,
-        IdType::MASTER,
-        Mode::LIM_SW,
+        device_type::MASTER,
+        mode::LIM_SW,
         port_,
         ((power_ >> 8) & 0xff) as u8,
         (power_ & 0xff) as u8,
         ((after_power_ >> 8) & 0xff) as u8,
         (after_power_ & 0xff) as u8,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000)).unwrap();
-    return receive_status(handle_, address_)
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(5000))
+        .unwrap();
+    return receive_status(handle_, address_);
 }
 
 /// Receive a data from the specified MD device.
@@ -140,7 +162,7 @@ pub fn send_limsw(handle_: &DeviceHandle<GlobalContext>, address_: u8, port_: u8
 /// Sample code to rotate a motor at 100 rpm and continuously retrieve rotation speed data.
 /// ```rust
 /// use motor_lib::{init_usb_handle, md, send_emergency};
-/// fn main() -> Result<(), motor_lib::Error> {
+/// fn main() -> Result<(), motor_lib::usb::USBError> {
 ///    let handle = init_usb_handle(0x483, 0x5740, 1).unwrap();
 ///    md::send_speed(&handle, 0x00, 100)?;
 ///    loop {
@@ -150,22 +172,26 @@ pub fn send_limsw(handle_: &DeviceHandle<GlobalContext>, address_: u8, port_: u8
 ///    Ok(())
 /// }
 /// ```
-#[allow(unused_variables)]
-pub fn receive_status(handle_: &DeviceHandle<GlobalContext>, address_: u8) -> Result<MdStatus, Error>{
-    let mut receive_buf = [0;8];
+pub fn receive_status(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+) -> Result<MdStatus, usb::USBError> {
+    let mut receive_buf = [0; 8];
     loop {
-        handle_.read_bulk(LIBUSB_ENDPOINT_IN | EndPont::EP1, &mut receive_buf, Duration::from_millis(5000)).unwrap();
+        handle_
+            .read_bulk(&mut receive_buf, Duration::from_millis(5000))
+            .unwrap();
         if address_ == receive_buf[0] {
             let rpm = count_to_rpm((receive_buf[4] as i16) << 8 | (receive_buf[5] as i16));
-            return Ok(MdStatus{
+            return Ok(MdStatus {
                 address: receive_buf[0],
                 semi_id: receive_buf[1],
                 angle: ((receive_buf[2] as i16) << 8 | (receive_buf[3] as i16)),
                 speed: rpm,
-                limsw: LimSwStatus{
+                limsw: LimSwStatus {
                     limsw_0: receive_buf[6] == 1,
                     limsw_1: receive_buf[7] == 1,
-                }
+                },
             });
         }
     }

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -1,10 +1,8 @@
 use std::time::Duration;
-use rusb::{constants:: LIBUSB_ENDPOINT_OUT, DeviceHandle, Error, GlobalContext};
 
-use crate::{IdType, EndPont};
+use crate::{device_type, usb};
 
-#[allow(non_snake_case)]
-pub mod Mode {
+pub mod mode {
     pub const STATUS: u8 = 0;
     pub const POWER: u8 = 1;
     pub const LIM_SW: u8 = 2;
@@ -26,56 +24,74 @@ pub struct SdStatus {
     pub limsw: LimSwStatus,
 }
 
-pub fn send_power(handle_: &DeviceHandle<GlobalContext>, address_: u8, port_: u8, power_: i16) -> Result<SdStatus, Error>{
+pub fn send_power(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+    port_: u8,
+    power_: i16,
+) -> Result<SdStatus, usb::USBError> {
     let power_abs = power_.abs();
     let send_buf: [u8; 8] = [
-        address_ | IdType::SD,
-        IdType::MASTER,
-        Mode::SINGLE_POWER,
+        address_ | device_type::SD,
+        device_type::MASTER,
+        mode::SINGLE_POWER,
         port_,
         ((power_abs >> 8) & 0xff) as u8,
         (power_abs & 0xff) as u8,
         0,
-        0
+        0,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000)).unwrap();
-    return receive_status(handle_, address_)
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(5000))
+        .unwrap();
+    return receive_status(handle_, address_);
 }
 
-pub fn send_powers(handle_: &DeviceHandle<GlobalContext>, address_: u8, power0_: i16, power1_ :i16) -> Result<SdStatus, Error>{
+pub fn send_powers(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+    power0_: i16,
+    power1_: i16,
+) -> Result<SdStatus, usb::USBError> {
     let power0_abs = power0_.abs();
     let power1_abs = power1_.abs();
 
     let send_buf: [u8; 8] = [
-        address_ | IdType::SD,
-        IdType::MASTER,
-        Mode::POWER,
+        address_ | device_type::SD,
+        device_type::MASTER,
+        mode::POWER,
         0,
         ((power0_abs >> 8) & 0xff) as u8,
         (power0_abs & 0xff) as u8,
         ((power1_abs >> 8) & 0xff) as u8,
         (power1_abs & 0xff) as u8,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000)).unwrap();
-    return receive_status(handle_, address_)
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(5000))
+        .unwrap();
+    return receive_status(handle_, address_);
 }
 
-#[allow(unused_variables)]
-pub fn receive_status(handle_: &DeviceHandle<GlobalContext>, address_: u8) -> Result<SdStatus, Error>{
-    let receive_buf = [0;8]; // SD側がデータ返送に対応するまでの仮実装
+pub fn receive_status(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+) -> Result<SdStatus, usb::USBError> {
+    let mut receive_buf = [0; 8];
     loop {
-        // handle_.read_bulk(LIBUSB_ENDPOINT_IN | EndPont::EP1, &mut receive_buf, Duration::from_millis(5000)).unwrap();
-        // if (address_ | IdType::SD) == receive_buf[0] {
-            return Ok(SdStatus{
+        handle_
+            .read_bulk(&mut receive_buf, Duration::from_millis(5000))
+            .unwrap();
+        if (address_ | device_type::SD) == receive_buf[0] {
+            return Ok(SdStatus {
                 address: receive_buf[0],
                 semi_id: receive_buf[1],
                 angle: ((receive_buf[2] as i16) << 8 | (receive_buf[3] as i16)),
                 speed: ((receive_buf[4] as i16) << 8 | (receive_buf[5] as i16)),
-                limsw: LimSwStatus{
+                limsw: LimSwStatus {
                     limsw_0: receive_buf[6] == 1,
                     limsw_1: receive_buf[7] == 1,
-                }
+                },
             });
-        // }
+        }
     }
 }

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -25,7 +25,7 @@ pub struct SdStatus {
 }
 
 pub fn send_power(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
     port_: u8,
     power_: i16,
@@ -48,7 +48,7 @@ pub fn send_power(
 }
 
 pub fn send_powers(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
     power0_: i16,
     power1_: i16,
@@ -73,7 +73,7 @@ pub fn send_powers(
 }
 
 pub fn receive_status(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
 ) -> Result<SdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -25,7 +25,7 @@ pub struct SdStatus {
 }
 
 pub fn send_power(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
     port_: u8,
     power_: i16,
@@ -48,7 +48,7 @@ pub fn send_power(
 }
 
 pub fn send_powers(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
     power0_: i16,
     power1_: i16,
@@ -73,7 +73,7 @@ pub fn send_powers(
 }
 
 pub fn receive_status(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
 ) -> Result<SdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -29,7 +29,7 @@ pub fn send_power(
     address_: u8,
     port_: u8,
     power_: i16,
-) -> Result<SdStatus, usb::USBError> {
+) -> Result<SdStatus, crate::USBError> {
     let power_abs = power_.abs();
     let send_buf: [u8; 8] = [
         address_ | device_type::SD,
@@ -52,7 +52,7 @@ pub fn send_powers(
     address_: u8,
     power0_: i16,
     power1_: i16,
-) -> Result<SdStatus, usb::USBError> {
+) -> Result<SdStatus, crate::USBError> {
     let power0_abs = power0_.abs();
     let power1_abs = power1_.abs();
 
@@ -75,7 +75,7 @@ pub fn send_powers(
 pub fn receive_status(
     handle_: &impl usb::USBHandleTrait,
     address_: u8,
-) -> Result<SdStatus, usb::USBError> {
+) -> Result<SdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];
     loop {
         handle_

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -24,6 +24,19 @@ pub struct SdStatus {
     pub limsw: LimSwStatus,
 }
 
+/// Sends a command to set the solenoid state on the specified SD port.
+/// ## Example
+/// Sets the state of the solenoid connected to port 0 of SD at address 0x10 to HIGH.
+/// It is recommended that the number set to the `power_` argument be 0 or 1000.
+/// ```rust
+/// use motor_lib::{USBHandle, USBError, sd};
+/// use std::time::Duration;
+/// fn main() -> Result<(), USBError> {
+///     let handle = USBHandle;
+///     sd::send_power(&handle, 0x10, 0, 1000)?;
+///     Ok(())
+/// }
+/// ```
 pub fn send_power(
     handle_: &impl usb::USBHandleTrait,
     address_: u8,
@@ -47,6 +60,19 @@ pub fn send_power(
     return receive_status(handle_, address_);
 }
 
+/// Sends a command to set the solenoid state on the specified SD.
+/// ## Example
+/// Sets the state of solenoids connected to ports 0 and 1 of SD to LOW and HIGH.
+/// It is recommended that the number set to the `power_` argument be 0 or 1000.
+/// ```rust
+/// use motor_lib::{USBHandle, USBError, sd};
+/// use std::time::Duration;
+/// fn main() -> Result<(), USBError> {
+///     let handle = USBHandle;
+///     sd::send_powers(&handle, 0x10, 0, 1000)?;
+///     Ok(())
+/// }
+/// ```
 pub fn send_powers(
     handle_: &impl usb::USBHandleTrait,
     address_: u8,

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -19,8 +19,8 @@ pub struct LimSwStatus {
 pub struct SdStatus {
     pub address: u8,
     pub semi_id: u8,
-    pub angle: i16,
-    pub speed: i16,
+    pub port_0: i16,
+    pub port_1: i16,
     pub limsw: LimSwStatus,
 }
 
@@ -111,8 +111,8 @@ pub fn receive_status(
             return Ok(SdStatus {
                 address: receive_buf[0],
                 semi_id: receive_buf[1],
-                angle: ((receive_buf[2] as i16) << 8 | (receive_buf[3] as i16)),
-                speed: ((receive_buf[4] as i16) << 8 | (receive_buf[5] as i16)),
+                port_0: ((receive_buf[2] as i16) << 8 | (receive_buf[3] as i16)),
+                port_1: ((receive_buf[4] as i16) << 8 | (receive_buf[5] as i16)),
                 limsw: LimSwStatus {
                     limsw_0: receive_buf[6] == 1,
                     limsw_1: receive_buf[7] == 1,

--- a/src/smd.rs
+++ b/src/smd.rs
@@ -1,10 +1,8 @@
 use std::time::Duration;
-use rusb::{constants::LIBUSB_ENDPOINT_OUT, DeviceHandle, Error, GlobalContext};
 
-use crate::{IdType, EndPont};
+use crate::{device_type, usb};
 
-#[allow(non_snake_case)]
-pub mod Mode {
+pub mod mode {
     pub const STATUS: u8 = 0;
     pub const ANGLE: u8 = 1;
     pub const ANGLES: u8 = 2;
@@ -18,48 +16,66 @@ pub struct SmdStatus {
     pub speed: i16,
 }
 
-pub fn send_angle(handle_: &DeviceHandle<GlobalContext>, address_: u8, port_: u8, angle_: u8) -> Result<SmdStatus, Error>{
+pub fn send_angle(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+    port_: u8,
+    angle_: u8,
+) -> Result<SmdStatus, usb::USBError> {
     let send_buf: [u8; 8] = [
-        address_ | IdType::SMD,
-        IdType::MASTER,
-        Mode::ANGLE,
+        address_ | device_type::SMD,
+        device_type::MASTER,
+        mode::ANGLE,
         port_,
         angle_,
         0,
         0,
-        0
+        0,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000)).unwrap();
-    return receive_status(handle_, address_)
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(5000))
+        .unwrap();
+    return receive_status(handle_, address_);
 }
 
-pub fn send_angles(handle_: &DeviceHandle<GlobalContext>, address_: u8, angle0_: u8, angle1_ :u8) -> Result<SmdStatus, Error>{
+pub fn send_angles(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+    angle0_: u8,
+    angle1_: u8,
+) -> Result<SmdStatus, usb::USBError> {
     let send_buf: [u8; 8] = [
-        address_ | IdType::SD,
-        IdType::MASTER,
-        Mode::ANGLES,
+        address_ | device_type::SD,
+        device_type::MASTER,
+        mode::ANGLES,
         0,
         angle0_,
         angle1_,
         0,
-        0
+        0,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000)).unwrap();
-    return receive_status(handle_, address_)
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(5000))
+        .unwrap();
+    return receive_status(handle_, address_);
 }
 
-#[allow(unused_variables)]
-pub fn receive_status(handle_: &DeviceHandle<GlobalContext>, address_: u8) -> Result<SmdStatus, Error>{
-    let receive_buf = [0;8]; // SMD側がデータ返送に対応するまでの仮実装
+pub fn receive_status(
+    handle_: &impl usb::USBHandleTrait,
+    address_: u8,
+) -> Result<SmdStatus, usb::USBError> {
+    let mut receive_buf = [0; 8];
     loop {
-        // handle_.read_bulk(LIBUSB_ENDPOINT_IN | EndPont::EP1, &mut receive_buf, Duration::from_millis(5000)).unwrap();
-        // if (address_ | IdType::SD) == receive_buf[0] {
-            return Ok(SmdStatus{
+        handle_
+            .read_bulk(&mut receive_buf, Duration::from_millis(5000))
+            .unwrap();
+        if (address_ | device_type::SD) == receive_buf[0] {
+            return Ok(SmdStatus {
                 address: receive_buf[0],
                 semi_id: receive_buf[1],
                 angle: ((receive_buf[2] as i16) << 8 | (receive_buf[3] as i16)),
                 speed: ((receive_buf[4] as i16) << 8 | (receive_buf[5] as i16)),
             });
-        // }
+        }
     }
 }

--- a/src/smd.rs
+++ b/src/smd.rs
@@ -21,7 +21,7 @@ pub fn send_angle(
     address_: u8,
     port_: u8,
     angle_: u8,
-) -> Result<SmdStatus, usb::USBError> {
+) -> Result<SmdStatus, crate::USBError> {
     let send_buf: [u8; 8] = [
         address_ | device_type::SMD,
         device_type::MASTER,
@@ -43,7 +43,7 @@ pub fn send_angles(
     address_: u8,
     angle0_: u8,
     angle1_: u8,
-) -> Result<SmdStatus, usb::USBError> {
+) -> Result<SmdStatus, crate::USBError> {
     let send_buf: [u8; 8] = [
         address_ | device_type::SD,
         device_type::MASTER,
@@ -63,7 +63,7 @@ pub fn send_angles(
 pub fn receive_status(
     handle_: &impl usb::USBHandleTrait,
     address_: u8,
-) -> Result<SmdStatus, usb::USBError> {
+) -> Result<SmdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];
     loop {
         handle_

--- a/src/smd.rs
+++ b/src/smd.rs
@@ -17,7 +17,7 @@ pub struct SmdStatus {
 }
 
 pub fn send_angle(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
     port_: u8,
     angle_: u8,
@@ -39,7 +39,7 @@ pub fn send_angle(
 }
 
 pub fn send_angles(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
     angle0_: u8,
     angle1_: u8,
@@ -61,7 +61,7 @@ pub fn send_angles(
 }
 
 pub fn receive_status(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     address_: u8,
 ) -> Result<SmdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];

--- a/src/smd.rs
+++ b/src/smd.rs
@@ -17,7 +17,7 @@ pub struct SmdStatus {
 }
 
 pub fn send_angle(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
     port_: u8,
     angle_: u8,
@@ -39,7 +39,7 @@ pub fn send_angle(
 }
 
 pub fn send_angles(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
     angle0_: u8,
     angle1_: u8,
@@ -61,7 +61,7 @@ pub fn send_angles(
 }
 
 pub fn receive_status(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     address_: u8,
 ) -> Result<SmdStatus, crate::USBError> {
     let mut receive_buf = [0; 8];

--- a/src/sr.rs
+++ b/src/sr.rs
@@ -25,7 +25,7 @@ pub struct SrStatus {
     pub freq: f32,
 }
 
-pub fn send_stop(handle_: &impl usb::USBHandleTrait) {
+pub fn send_stop(handle_: &mut impl usb::USBHandleTrait) {
     let send_buf: [u8; 8] = [
         device_type::SR,
         device_type::MASTER,
@@ -40,7 +40,7 @@ pub fn send_stop(handle_: &impl usb::USBHandleTrait) {
         .write_bulk(&send_buf, Duration::from_millis(5000))
         .unwrap();
 }
-pub fn send_start(handle_: &impl usb::USBHandleTrait, timeout: u16) {
+pub fn send_start(handle_: &mut impl usb::USBHandleTrait, timeout: u16) {
     let send_buf: [u8; 8] = [
         device_type::SR,
         device_type::MASTER,
@@ -56,7 +56,7 @@ pub fn send_start(handle_: &impl usb::USBHandleTrait, timeout: u16) {
         .unwrap();
 }
 pub fn send_colors(
-    handle_: &impl usb::USBHandleTrait,
+    handle_: &mut impl usb::USBHandleTrait,
     red: u8,
     green: u8,
     blue: u8,

--- a/src/sr.rs
+++ b/src/sr.rs
@@ -25,7 +25,7 @@ pub struct SrStatus {
     pub freq: f32,
 }
 
-pub fn send_stop(handle_: &mut impl usb::USBHandleTrait) {
+pub fn send_stop(handle_: &impl usb::USBHandleTrait) {
     let send_buf: [u8; 8] = [
         device_type::SR,
         device_type::MASTER,
@@ -40,7 +40,7 @@ pub fn send_stop(handle_: &mut impl usb::USBHandleTrait) {
         .write_bulk(&send_buf, Duration::from_millis(5000))
         .unwrap();
 }
-pub fn send_start(handle_: &mut impl usb::USBHandleTrait, timeout: u16) {
+pub fn send_start(handle_: &impl usb::USBHandleTrait, timeout: u16) {
     let send_buf: [u8; 8] = [
         device_type::SR,
         device_type::MASTER,
@@ -56,7 +56,7 @@ pub fn send_start(handle_: &mut impl usb::USBHandleTrait, timeout: u16) {
         .unwrap();
 }
 pub fn send_colors(
-    handle_: &mut impl usb::USBHandleTrait,
+    handle_: &impl usb::USBHandleTrait,
     red: u8,
     green: u8,
     blue: u8,

--- a/src/sr.rs
+++ b/src/sr.rs
@@ -1,10 +1,8 @@
 use std::time::Duration;
-use rusb::{constants::LIBUSB_ENDPOINT_OUT, DeviceHandle, GlobalContext};
 
-use crate::{IdType, EndPont};
+use crate::{device_type, usb};
 
-#[allow(non_snake_case)]
-pub mod Mode {
+pub mod mode {
     pub const STATUS: u8 = 0;
     pub const STOP: u8 = 1;
     pub const START: u8 = 2;
@@ -27,42 +25,55 @@ pub struct SrStatus {
     pub freq: f32,
 }
 
-pub fn send_stop(handle_: &DeviceHandle<GlobalContext>) {
+pub fn send_stop(handle_: &impl usb::USBHandleTrait) {
     let send_buf: [u8; 8] = [
-        IdType::SR,
-        IdType::MASTER,
-        Mode::STOP,
+        device_type::SR,
+        device_type::MASTER,
+        mode::STOP,
         0,
         0,
         0,
         0,
-        0
+        0,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(5000)).unwrap();
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(5000))
+        .unwrap();
 }
-pub fn send_start(handle_: &DeviceHandle<GlobalContext>, timeout: u16) {
+pub fn send_start(handle_: &impl usb::USBHandleTrait, timeout: u16) {
     let send_buf: [u8; 8] = [
-        IdType::SR,
-        IdType::MASTER,
-        Mode::START,
+        device_type::SR,
+        device_type::MASTER,
+        mode::START,
         0,
         0,
         0,
         0,
-        0
+        0,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(timeout.into())).unwrap();
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(timeout.into()))
+        .unwrap();
 }
-pub fn send_colors(handle_: &DeviceHandle<GlobalContext>, red: u8, green: u8, blue: u8, freq: f32, timeout: u16) {
+pub fn send_colors(
+    handle_: &impl usb::USBHandleTrait,
+    red: u8,
+    green: u8,
+    blue: u8,
+    freq: f32,
+    timeout: u16,
+) {
     let send_buf: [u8; 8] = [
-        IdType::SR,
-        IdType::MASTER,
-        Mode::COLOR,
+        device_type::SR,
+        device_type::MASTER,
+        mode::COLOR,
         0,
         green,
         red,
         blue,
-        (freq * 4.0) as u8
+        (freq * 4.0) as u8,
     ];
-    handle_.write_bulk(LIBUSB_ENDPOINT_OUT | EndPont::EP1, &send_buf, Duration::from_millis(timeout.into())).unwrap();
+    handle_
+        .write_bulk(&send_buf, Duration::from_millis(timeout.into()))
+        .unwrap();
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -1,0 +1,68 @@
+//! Implementation of an abstraction layer for accessing USB devices.
+
+use rusb::constants::{LIBUSB_ENDPOINT_IN, LIBUSB_ENDPOINT_OUT};
+use rusb::{DeviceHandle, GlobalContext};
+use std::{fmt, sync::LazyLock, time};
+
+const VENDOR_ID: u16 = 0x483;
+const PRODUCT_ID: u16 = 0x5740;
+const B_INTERFACE_NUMBER: u8 = 1;
+static HANDLE: LazyLock<DeviceHandle<GlobalContext>> = LazyLock::new(|| {
+    use rusb::open_device_with_vid_pid;
+    let handle = open_device_with_vid_pid(VENDOR_ID, PRODUCT_ID).unwrap();
+    handle.set_auto_detach_kernel_driver(true).unwrap_or(());
+    handle.claim_interface(B_INTERFACE_NUMBER).unwrap();
+    handle
+});
+
+pub mod end_point {
+    pub static EP1: u8 = 1;
+}
+
+#[derive(Debug)]
+pub enum USBError {
+    RUsbError(rusb::Error),
+}
+impl fmt::Display for USBError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            USBError::RUsbError(e) => write!(f, "RUsbError: {}", e),
+        }
+    }
+}
+impl From<rusb::Error> for USBError {
+    fn from(error: rusb::Error) -> Self {
+        USBError::RUsbError(error)
+    }
+}
+
+pub struct USBHandle;
+pub struct MockUSBHandle;
+
+pub trait USBHandleTrait {
+    fn read_bulk(&self, data: &mut [u8], timeout: time::Duration) -> Result<usize, USBError>;
+    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, USBError>;
+}
+
+impl USBHandleTrait for USBHandle {
+    fn read_bulk(&self, data: &mut [u8], timeout: time::Duration) -> Result<usize, USBError> {
+        let result = HANDLE
+            .read_bulk(LIBUSB_ENDPOINT_IN | end_point::EP1, data, timeout)
+            .map_err(USBError::from);
+        result
+    }
+    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, USBError> {
+        let result = HANDLE
+            .write_bulk(LIBUSB_ENDPOINT_OUT | end_point::EP1, data, timeout)
+            .map_err(USBError::from);
+        result
+    }
+}
+impl USBHandleTrait for MockUSBHandle {
+    fn write_bulk(&self, _data: &[u8], _timeout: time::Duration) -> Result<usize, USBError> {
+        Ok(8)
+    }
+    fn read_bulk(&self, _data: &mut [u8], _timeout: time::Duration) -> Result<usize, USBError> {
+        Ok(8)
+    }
+}

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -15,54 +15,43 @@ static HANDLE: LazyLock<DeviceHandle<GlobalContext>> = LazyLock::new(|| {
     handle
 });
 
-pub mod end_point {
+mod end_point {
     pub static EP1: u8 = 1;
 }
 
-#[derive(Debug)]
-pub enum USBError {
-    RUsbError(rusb::Error),
-}
-impl fmt::Display for USBError {
+impl fmt::Display for crate::USBError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            USBError::RUsbError(e) => write!(f, "RUsbError: {}", e),
+            crate::USBError::RUsbError(e) => write!(f, "RUsbError: {}", e),
         }
     }
 }
-impl From<rusb::Error> for USBError {
+impl From<rusb::Error> for crate::USBError {
     fn from(error: rusb::Error) -> Self {
-        USBError::RUsbError(error)
+        crate::USBError::RUsbError(error)
     }
 }
-
-pub struct USBHandle;
-pub struct MockUSBHandle;
 
 pub trait USBHandleTrait {
-    fn read_bulk(&self, data: &mut [u8], timeout: time::Duration) -> Result<usize, USBError>;
-    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, USBError>;
+    fn read_bulk(&self, data: &mut [u8], timeout: time::Duration)
+        -> Result<usize, crate::USBError>;
+    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError>;
 }
-
-impl USBHandleTrait for USBHandle {
-    fn read_bulk(&self, data: &mut [u8], timeout: time::Duration) -> Result<usize, USBError> {
+impl USBHandleTrait for crate::USBHandle {
+    fn read_bulk(
+        &self,
+        data: &mut [u8],
+        timeout: time::Duration,
+    ) -> Result<usize, crate::USBError> {
         let result = HANDLE
             .read_bulk(LIBUSB_ENDPOINT_IN | end_point::EP1, data, timeout)
-            .map_err(USBError::from);
+            .map_err(crate::USBError::from);
         result
     }
-    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, USBError> {
+    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError> {
         let result = HANDLE
             .write_bulk(LIBUSB_ENDPOINT_OUT | end_point::EP1, data, timeout)
-            .map_err(USBError::from);
+            .map_err(crate::USBError::from);
         result
-    }
-}
-impl USBHandleTrait for MockUSBHandle {
-    fn write_bulk(&self, _data: &[u8], _timeout: time::Duration) -> Result<usize, USBError> {
-        Ok(8)
-    }
-    fn read_bulk(&self, _data: &mut [u8], _timeout: time::Duration) -> Result<usize, USBError> {
-        Ok(8)
     }
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -35,7 +35,7 @@ impl From<rusb::Error> for crate::USBError {
 pub trait USBHandleTrait {
     fn read_bulk(&self, data: &mut [u8], timeout: time::Duration)
         -> Result<usize, crate::USBError>;
-    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError>;
+    fn write_bulk(&mut self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError>;
 }
 impl USBHandleTrait for crate::USBHandle {
     fn read_bulk(
@@ -48,7 +48,7 @@ impl USBHandleTrait for crate::USBHandle {
             .map_err(crate::USBError::from);
         result
     }
-    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError> {
+    fn write_bulk(&mut self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError> {
         let result = HANDLE
             .write_bulk(LIBUSB_ENDPOINT_OUT | end_point::EP1, data, timeout)
             .map_err(crate::USBError::from);

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -35,7 +35,7 @@ impl From<rusb::Error> for crate::USBError {
 pub trait USBHandleTrait {
     fn read_bulk(&self, data: &mut [u8], timeout: time::Duration)
         -> Result<usize, crate::USBError>;
-    fn write_bulk(&mut self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError>;
+    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError>;
 }
 impl USBHandleTrait for crate::USBHandle {
     fn read_bulk(
@@ -48,7 +48,7 @@ impl USBHandleTrait for crate::USBHandle {
             .map_err(crate::USBError::from);
         result
     }
-    fn write_bulk(&mut self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError> {
+    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError> {
         let result = HANDLE
             .write_bulk(LIBUSB_ENDPOINT_OUT | end_point::EP1, data, timeout)
             .map_err(crate::USBError::from);


### PR DESCRIPTION
# 概要
テスト実装(#8)の前段階として，usbデバイスを抽象化しました．  
これでusb-can-hardwareを繋いでいない環境でも最低限関数の定義が正しいかくらいのテストを回せるようになります．
# 見てほしいところ
コードの変更量がえらいことになっています．新しいことをたくさんやっているので，コードの意味や動くかどうかをしっかり確認してからマージしたいです．