### PR TITLE
複数プロセスからusb_canにアクセスできるようにした

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,9 @@ edition = "2021"
 [dependencies]
 advanced-pid = "0.2.2"
 rusb = "0.9"
+tonic = "0.12"
+prost = "0.13"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+
+[build-dependencies]
+tonic-build = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,14 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "sample_1"
+path = "src/bin/sample/sample_1.rs"
+
+[[bin]]
+name = "sample_2"
+path = "src/bin/sample/sample_2.rs"
+
 [dependencies]
 advanced-pid = "0.2.2"
 rusb = "0.9"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("proto/motor_lib.proto")?;
+    Ok(())
+}

--- a/proto/motor_lib.proto
+++ b/proto/motor_lib.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+package motor_lib;
+
+import "google/protobuf/empty.proto";
+service UsbCan {
+    rpc Read (google.protobuf.Empty) returns (UsbCanResponse);
+    rpc Write (UsbCanRequest) returns (google.protobuf.Empty);
+}
+
+message UsbCanRequest {
+   bytes send_buf = 1;
+}
+
+message UsbCanResponse {
+    bytes recv_buf = 1;
+}

--- a/src/bin/sample/sample_1.rs
+++ b/src/bin/sample/sample_1.rs
@@ -1,0 +1,14 @@
+use motor_lib::{grpc::pb, md, GrpcHandle};
+use std::cell::RefCell;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tokio_context = tokio::runtime::Runtime::new().unwrap();
+    let client = tokio_context.block_on(async {
+        pb::usb_can_client::UsbCanClient::connect("http://127.0.0.1:50051")
+            .await
+            .unwrap()
+    });
+    let handle = GrpcHandle::new(tokio_context, RefCell::new(client));
+    md::send_pwm(&handle, 0x00, 1000).unwrap();
+    Ok(())
+}

--- a/src/bin/sample/sample_1.rs
+++ b/src/bin/sample/sample_1.rs
@@ -1,14 +1,7 @@
-use motor_lib::{grpc::pb, md, GrpcHandle};
-use std::cell::RefCell;
+use motor_lib::{md, GrpcHandle};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let tokio_context = tokio::runtime::Runtime::new().unwrap();
-    let client = tokio_context.block_on(async {
-        pb::usb_can_client::UsbCanClient::connect("http://127.0.0.1:50051")
-            .await
-            .unwrap()
-    });
-    let handle = GrpcHandle::new(tokio_context, RefCell::new(client));
+    let handle = GrpcHandle::new("http://127.0.0.1:50051");
     md::send_pwm(&handle, 0x00, 1000).unwrap();
     Ok(())
 }

--- a/src/bin/sample/sample_2.rs
+++ b/src/bin/sample/sample_2.rs
@@ -1,0 +1,14 @@
+use motor_lib::{grpc::pb, md, GrpcHandle};
+use std::cell::RefCell;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tokio_context = tokio::runtime::Runtime::new().unwrap();
+    let client = tokio_context.block_on(async {
+        pb::usb_can_client::UsbCanClient::connect("http://127.0.0.1:50051")
+            .await
+            .unwrap()
+    });
+    let handle = GrpcHandle::new(tokio_context, RefCell::new(client));
+    md::send_pwm(&handle, 0x01, 1000).unwrap();
+    Ok(())
+}

--- a/src/bin/sample/sample_2.rs
+++ b/src/bin/sample/sample_2.rs
@@ -1,14 +1,7 @@
-use motor_lib::{grpc::pb, md, GrpcHandle};
-use std::cell::RefCell;
+use motor_lib::{md, GrpcHandle};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let tokio_context = tokio::runtime::Runtime::new().unwrap();
-    let client = tokio_context.block_on(async {
-        pb::usb_can_client::UsbCanClient::connect("http://127.0.0.1:50051")
-            .await
-            .unwrap()
-    });
-    let handle = GrpcHandle::new(tokio_context, RefCell::new(client));
+    let handle = GrpcHandle::new("http://127.0.0.1:50051");
     md::send_pwm(&handle, 0x01, 1000).unwrap();
     Ok(())
 }

--- a/src/bin/usb_can_server.rs
+++ b/src/bin/usb_can_server.rs
@@ -1,0 +1,59 @@
+pub mod pb {
+    tonic::include_proto!("motor_lib");
+}
+
+use rusb::constants::{LIBUSB_ENDPOINT_IN, LIBUSB_ENDPOINT_OUT};
+use std::{net::ToSocketAddrs, time};
+use tonic::transport::Server;
+
+const EP1: u8 = 1;
+const TIMEOUT: time::Duration = time::Duration::from_millis(5000);
+
+#[derive(Debug)]
+pub struct UsbCanServer {
+    handle: rusb::DeviceHandle<rusb::GlobalContext>,
+}
+
+#[tonic::async_trait]
+impl pb::usb_can_server::UsbCan for UsbCanServer {
+    async fn read(
+        &self,
+        _request: tonic::Request<()>,
+    ) -> Result<tonic::Response<pb::UsbCanResponse>, tonic::Status> {
+        let mut recv_buf = vec![0; 8];
+        self.handle
+            .read_bulk(LIBUSB_ENDPOINT_IN | EP1, &mut recv_buf, TIMEOUT)
+            .unwrap();
+        Ok(tonic::Response::new(pb::UsbCanResponse {
+            recv_buf: recv_buf,
+        }))
+    }
+    async fn write(
+        &self,
+        _request: tonic::Request<pb::UsbCanRequest>,
+    ) -> Result<tonic::Response<()>, tonic::Status> {
+        let send_buf = vec![0; 8];
+        self.handle
+            .write_bulk(LIBUSB_ENDPOINT_OUT | EP1, &send_buf, TIMEOUT)
+            .unwrap();
+        Ok(tonic::Response::<()>::new(()))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const VENDOR_ID: u16 = 0x483;
+    const PRODUCT_ID: u16 = 0x5740;
+    const B_INTERFACE_NUMBER: u8 = 1;
+    let handle = rusb::open_device_with_vid_pid(VENDOR_ID, PRODUCT_ID).unwrap();
+    handle.set_auto_detach_kernel_driver(true).unwrap_or(());
+    handle.claim_interface(B_INTERFACE_NUMBER).unwrap();
+
+    let server = UsbCanServer { handle };
+    Server::builder()
+        .add_service(pb::usb_can_server::UsbCanServer::new(server))
+        .serve("[::1]:50051".to_socket_addrs().unwrap().next().unwrap())
+        .await
+        .unwrap();
+    Ok(())
+}

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -9,12 +9,17 @@ use pb::UsbCanRequest;
 
 impl GrpcHandle {
     pub fn new(
-        tokio_context: tokio::runtime::Runtime,
-        client: std::cell::RefCell<pb::usb_can_client::UsbCanClient<tonic::transport::Channel>>,
+        url: &str
     ) -> Self {
+        let tokio_context = tokio::runtime::Runtime::new().unwrap();
+        let client = tokio_context.block_on(async{
+            pb::usb_can_client::UsbCanClient::connect(url.to_string())
+                .await
+                .unwrap()
+        });
         Self {
-            tokio_context,
-            client,
+            tokio_context: tokio_context,
+            client: std::cell::RefCell::new(client),
         }
     }
 }

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -7,6 +7,18 @@ pub mod pb {
 
 use pb::UsbCanRequest;
 
+impl GrpcHandle {
+    pub fn new(
+        tokio_context: tokio::runtime::Runtime,
+        client: std::cell::RefCell<pb::usb_can_client::UsbCanClient<tonic::transport::Channel>>,
+    ) -> Self {
+        Self {
+            tokio_context,
+            client,
+        }
+    }
+}
+
 impl USBHandleTrait for GrpcHandle {
     fn read_bulk(
         &self,
@@ -14,7 +26,7 @@ impl USBHandleTrait for GrpcHandle {
         _timeout: time::Duration,
     ) -> Result<usize, crate::USBError> {
         let request = tonic::Request::new(());
-        let response = tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let response = self.tokio_context.block_on(async {
             let response = self.client.borrow_mut().read(request).await.unwrap();
             return response.into_inner().recv_buf;
         });
@@ -25,7 +37,7 @@ impl USBHandleTrait for GrpcHandle {
         let request = tonic::Request::new(UsbCanRequest {
             send_buf: data.to_vec(),
         });
-        tokio::runtime::Runtime::new().unwrap().block_on(async {
+        self.tokio_context.block_on(async {
             self.client.borrow_mut().write(request).await.unwrap();
         });
         Ok(data.len())

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -8,11 +8,9 @@ pub mod pb {
 use pb::UsbCanRequest;
 
 impl GrpcHandle {
-    pub fn new(
-        url: &str
-    ) -> Self {
+    pub fn new(url: &str) -> Self {
         let tokio_context = tokio::runtime::Runtime::new().unwrap();
-        let client = tokio_context.block_on(async{
+        let client = tokio_context.block_on(async {
             pb::usb_can_client::UsbCanClient::connect(url.to_string())
                 .await
                 .unwrap()

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -1,0 +1,33 @@
+use crate::{usb::USBHandleTrait, GrpcHandle};
+use std::time;
+
+pub mod pb {
+    tonic::include_proto!("motor_lib");
+}
+
+use pb::UsbCanRequest;
+
+impl USBHandleTrait for GrpcHandle {
+    fn read_bulk(
+        &self,
+        data: &mut [u8],
+        _timeout: time::Duration,
+    ) -> Result<usize, crate::USBError> {
+        let request = tonic::Request::new(());
+        let response = tokio::runtime::Runtime::new().unwrap().block_on(async {
+            let response = self.client.borrow_mut().read(request).await.unwrap();
+            return response.into_inner().recv_buf;
+        });
+        data.copy_from_slice(&response);
+        Ok(response.len())
+    }
+    fn write_bulk(&self, data: &[u8], _timeout: time::Duration) -> Result<usize, crate::USBError> {
+        let request = tonic::Request::new(UsbCanRequest {
+            send_buf: data.to_vec(),
+        });
+        tokio::runtime::Runtime::new().unwrap().block_on(async {
+            self.client.borrow_mut().write(request).await.unwrap();
+        });
+        Ok(data.len())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,9 @@ pub mod device_type {
 }
 
 /// A handle to read and write an USB device.
-pub struct USBHandle;
+pub struct USBHandle {
+    handle: rusb::DeviceHandle<rusb::GlobalContext>,
+}
 
 pub struct GrpcHandle {
     tokio_context: tokio::runtime::Runtime,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub enum USBError {
 /// ```rust
 /// use motor_lib::{USBHandle, send_emergency};
 /// fn main() {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     send_emergency(&handle);
 /// }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod device_type {
 pub struct USBHandle;
 
 pub struct GrpcHandle {
+    tokio_context: tokio::runtime::Runtime,
     client: RefCell<grpc::pb::usb_can_client::UsbCanClient<tonic::transport::Channel>>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 //! This library provides an interface for controlling various motor devices via USB.
-
+use std::cell::RefCell;
 use std::time::Duration;
 
 pub mod blmd;
+pub mod grpc;
 pub mod md;
 pub mod sd;
 pub mod smd;
@@ -31,6 +32,10 @@ pub mod device_type {
 
 /// A handle to read and write an USB device.
 pub struct USBHandle;
+
+pub struct GrpcHandle {
+    client: RefCell<grpc::pb::usb_can_client::UsbCanClient<tonic::transport::Channel>>,
+}
 
 #[derive(Debug)]
 pub enum USBError {

--- a/src/md.rs
+++ b/src/md.rs
@@ -47,7 +47,7 @@ pub struct MdStatus {
 /// ```rust
 /// use motor_lib::{USBHandle, USBError, md};
 /// fn main() {
-///    let handle = USBHandle;
+///    let handle = USBHandle::new(0x483, 0x5740, 1);
 ///    let return_status =
 ///    loop {
 ///         match md::send_pwm(&handle, 0x00, 1000) {
@@ -100,7 +100,7 @@ pub fn send_pwm(
 /// use motor_lib::{USBHandle, USBError, md};
 /// use std::time::Duration;
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     md::send_speed(&handle, 0x00, 100)?;
 ///     Ok(())
 /// }
@@ -146,7 +146,7 @@ pub fn send_speed(
 /// ```rust
 /// use motor_lib::{USBHandle, USBError, md};
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     md::send_angle(&handle, 0x00, 90)?;
 ///     Ok(())
 /// }
@@ -193,8 +193,8 @@ pub fn send_angle(
 /// ```rust
 /// use motor_lib::{USBHandle, USBError, md};
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
-///     md::send_limsw(&handle, 0x00, 1, 1000, 500)?;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
+///     let status = md::send_limsw(&handle, 0x00, 1, 1000, 500)?;
 ///     Ok(())
 /// }
 /// ```
@@ -240,7 +240,7 @@ pub fn send_limsw(
 /// use std::thread::sleep;
 /// use std::time::Duration;
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     md::send_speed(&handle, 0x00, 100)?;
 ///     std::thread::sleep(Duration::from_secs(1));
 ///     let status = md::receive_status(&handle, 0x00)?;

--- a/src/sd.rs
+++ b/src/sd.rs
@@ -46,7 +46,7 @@ pub struct SdStatus {
 /// ```rust
 /// use motor_lib::{USBHandle, USBError, sd};
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     sd::send_power(&handle, 0x10, 0, 1000)?;
 ///     Ok(())
 /// }
@@ -94,7 +94,7 @@ pub fn send_power(
 /// ```rust
 /// use motor_lib::{USBHandle, USBError, sd};
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     sd::send_powers(&handle, 0x10, 0, 1000)?;
 ///     Ok(())
 /// }
@@ -141,7 +141,7 @@ pub fn send_powers(
 /// ```rust
 /// use motor_lib::{USBHandle, USBError, sd};
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     let status = sd::receive_status(&handle, 0x10)?;
 ///     println!("{:?}", status);
 ///     Ok(())

--- a/src/smd.rs
+++ b/src/smd.rs
@@ -37,7 +37,7 @@ pub struct SmdStatus {
 /// ```rust
 /// use motor_lib::{USBHandle, USBError, smd};
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     smd::send_angle(&handle, 0x20, 1, 45)?;
 ///     Ok(())
 /// }
@@ -83,7 +83,7 @@ pub fn send_angle(
 /// ```rust
 /// use motor_lib::{USBHandle, USBError, smd};
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     smd::send_angles(&handle, 0x20, 30, 60)?;
 ///     Ok(())
 /// }
@@ -127,7 +127,7 @@ pub fn send_angles(
 /// ```rust
 /// use motor_lib::{USBHandle, USBError, smd};
 /// fn main() -> Result<(), USBError> {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     let status = smd::receive_status(&handle, 0x20)?;
 ///     println!("{:?}", status);
 ///     Ok(())

--- a/src/sr.rs
+++ b/src/sr.rs
@@ -39,7 +39,7 @@ pub struct SrStatus {
 /// ```rust
 /// use motor_lib::{USBHandle, sr};
 /// fn main() {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     sr::send_stop(&handle);
 /// }
 /// ```
@@ -72,7 +72,7 @@ pub fn send_stop(handle: &impl usb::USBHandleTrait) {
 /// ```rust
 /// use motor_lib::{USBHandle, sr};
 /// fn main() {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     sr::send_start(&handle, 1000);
 /// }
 /// ```
@@ -109,7 +109,7 @@ pub fn send_start(handle: &impl usb::USBHandleTrait, timeout: u16) {
 /// ```rust
 /// use motor_lib::{USBHandle, sr};
 /// fn main() {
-///     let handle = USBHandle;
+///     let handle = USBHandle::new(0x483, 0x5740, 1);
 ///     sr::send_colors(&handle, 255, 0, 0, 0.0, 1000);
 /// }
 /// ```

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -60,6 +60,12 @@ pub trait USBHandleTrait {
     fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError>;
 }
 
+impl crate::USBHandle {
+    pub fn new() -> Self {
+        Self{}
+    }
+}
+
 /// Implementation of the USBHandleTrait for the USBHandle struct.
 impl USBHandleTrait for crate::USBHandle {
     fn read_bulk(

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -62,7 +62,7 @@ pub trait USBHandleTrait {
 
 impl crate::USBHandle {
     pub fn new() -> Self {
-        Self{}
+        Self {}
     }
 }
 

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -1,34 +1,24 @@
 //! Implementation of an abstraction layer for accessing USB devices.
 
+use crate::{USBError, USBHandle};
 use rusb::constants::{LIBUSB_ENDPOINT_IN, LIBUSB_ENDPOINT_OUT};
-use rusb::{DeviceHandle, GlobalContext};
-use std::{fmt, sync::LazyLock, time};
-
-const VENDOR_ID: u16 = 0x483;
-const PRODUCT_ID: u16 = 0x5740;
-const B_INTERFACE_NUMBER: u8 = 1;
-static HANDLE: LazyLock<DeviceHandle<GlobalContext>> = LazyLock::new(|| {
-    use rusb::open_device_with_vid_pid;
-    let handle = open_device_with_vid_pid(VENDOR_ID, PRODUCT_ID).unwrap();
-    handle.set_auto_detach_kernel_driver(true).unwrap_or(());
-    handle.claim_interface(B_INTERFACE_NUMBER).unwrap();
-    handle
-});
+use rusb::open_device_with_vid_pid;
+use std::{fmt, time};
 
 mod end_point {
     pub static EP1: u8 = 1;
 }
 
-impl fmt::Display for crate::USBError {
+impl fmt::Display for USBError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            crate::USBError::RUsbError(e) => write!(f, "RUsbError: {}", e),
+            USBError::RUsbError(e) => write!(f, "RUsbError: {}", e),
         }
     }
 }
-impl From<rusb::Error> for crate::USBError {
+impl From<rusb::Error> for USBError {
     fn from(error: rusb::Error) -> Self {
-        crate::USBError::RUsbError(error)
+        USBError::RUsbError(error)
     }
 }
 
@@ -44,8 +34,7 @@ pub trait USBHandleTrait {
     /// # Returns
     ///
     /// A result containing the number of bytes read or a USBError.
-    fn read_bulk(&self, data: &mut [u8], timeout: time::Duration)
-        -> Result<usize, crate::USBError>;
+    fn read_bulk(&self, data: &mut [u8], timeout: time::Duration) -> Result<usize, USBError>;
 
     /// Writes data to a USB device using bulk transfer.
     ///
@@ -57,32 +46,33 @@ pub trait USBHandleTrait {
     /// # Returns
     ///
     /// A result containing the number of bytes written or a USBError.
-    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError>;
+    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, USBError>;
 }
 
-impl crate::USBHandle {
-    pub fn new() -> Self {
-        Self {}
+impl USBHandle {
+    pub fn new(vendor_id: u16, product_id: u16, b_interface_number: u8) -> Self {
+        let handle = open_device_with_vid_pid(vendor_id, product_id).unwrap();
+        handle.set_auto_detach_kernel_driver(true).unwrap_or(());
+        handle.claim_interface(b_interface_number).unwrap();
+        Self { handle }
     }
 }
 
 /// Implementation of the USBHandleTrait for the USBHandle struct.
-impl USBHandleTrait for crate::USBHandle {
-    fn read_bulk(
-        &self,
-        data: &mut [u8],
-        timeout: time::Duration,
-    ) -> Result<usize, crate::USBError> {
-        let result = HANDLE
+impl USBHandleTrait for USBHandle {
+    fn read_bulk(&self, data: &mut [u8], timeout: time::Duration) -> Result<usize, USBError> {
+        let result = self
+            .handle
             .read_bulk(LIBUSB_ENDPOINT_IN | end_point::EP1, data, timeout)
-            .map_err(crate::USBError::from);
+            .map_err(USBError::from);
         result
     }
 
-    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, crate::USBError> {
-        let result = HANDLE
+    fn write_bulk(&self, data: &[u8], timeout: time::Duration) -> Result<usize, USBError> {
+        let result = self
+            .handle
             .write_bulk(LIBUSB_ENDPOINT_OUT | end_point::EP1, data, timeout)
-            .map_err(crate::USBError::from);
+            .map_err(USBError::from);
         result
     }
 }


### PR DESCRIPTION
## 概要
gRPCサーバーとクライアントを実装しました．
サーバーがpigpiod，クライアントがpigpiod_if2だと思うとわかりやすいと思います．
## 詳細
RaspberryPiの高度なペリフェラルアクセスを提供するライブラリであるpigpioは，Socket通信によって複数プロセスからペリフェラルにアクセスできるインターフェイスであるpigpiod_if2を提供しています．motor_libをこれに似たような使い方ができるようにするためにgRPCを用いて実装したのが今回のPRになります．

以下，GitHub Copilotによる自動生成
## Summary
This pull request introduces gRPC functionality to the project, adds new dependencies, and refactors the USB handling code to support both USB and gRPC communication. The most important changes include adding new binaries and dependencies in `Cargo.toml`, creating a new `build.rs` file for compiling protobufs, defining the gRPC service in `proto/motor_lib.proto`, implementing the gRPC client in `src/grpc.rs`, and refactoring the USB handling code in `src/usb.rs`.

### gRPC Integration:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R8-R24): Added new binaries (`sample_1` and `sample_2`) and dependencies (`tonic`, `prost`, `tokio`, and `tonic-build`).
* [`build.rs`](diffhunk://#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42R1-R4): Created a new build script to compile protobuf definitions using `tonic-build`.
* [`proto/motor_lib.proto`](diffhunk://#diff-4cd9b21718008464fc60980bf71454ecda739332cc86c0c84c9f69f614bc83d1R1-R16): Defined the gRPC service `UsbCan` with `Read` and `Write` RPC methods, and the corresponding request and response messages.
* [`src/grpc.rs`](diffhunk://#diff-e65d3d4107d1ca50872d5d1ecec64de5c8b1fd31de3e0fca8e16becfd98c68b8R1-R48): Implemented the gRPC client `GrpcHandle` and its methods for reading and writing data using gRPC.

### USB Handling Refactor:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L2-R6): Added `grpc` module and refactored `USBHandle` to include the actual USB device handle. Introduced `GrpcHandle` for gRPC communication. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L2-R6) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L33-R41)
* [`src/usb.rs`](diffhunk://#diff-3a9747812d15017b0336243fa7c2a0374feef5f48031945737a7a9f0e4e42875R3-R21): Refactored the USB handling code to use the instance-specific device handle instead of a static handle. Updated the `USBHandleTrait` to support both USB and gRPC implementations. [[1]](diffhunk://#diff-3a9747812d15017b0336243fa7c2a0374feef5f48031945737a7a9f0e4e42875R3-R21) [[2]](diffhunk://#diff-3a9747812d15017b0336243fa7c2a0374feef5f48031945737a7a9f0e4e42875L47-R37) [[3]](diffhunk://#diff-3a9747812d15017b0336243fa7c2a0374feef5f48031945737a7a9f0e4e42875L60-R75)