### PR TITLE
環境構築が不要になった

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,10 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install protobuf-compiler
       - name: Build
         run: cargo build --verbose
   #    - name: Run tests
@@ -28,10 +24,6 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v2
-      - name: Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install protobuf-compiler
       - name: Run doc
         run: cargo doc --no-deps
       - name: Deploy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ prost = "0.13"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
-tonic-build = "*"
+protox = "0.7"
+tonic-build = "0.12"
 
 [[example]]
 name = "sample_1"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("proto/motor_lib.proto")?;
+    let file_descriptors = protox::compile(["motor_lib.proto"], ["proto/"]).unwrap();
+    tonic_build::configure()
+        .build_server(true)
+        .compile_fds(file_descriptors)
+        .unwrap();
     Ok(())
 }


### PR DESCRIPTION
## 概要
gRPCを使用するにあたり、Protocol Buffersを各言語向けにコンパイルするためのprotocというソフトウェアを事前にインストールしておく必要がありました。
しかし、motor_libは機械班なども使用するものであるため、面倒な環境構築が必要になるのはなるべく避ける必要があります。
そこで、Rust製のProtocol Buffersコンパイラであるprotoxを使用することで、環境構築を不要としました。
## チェックしてほしいところ
ありません。masterにPRを投げるときにActionsのビルドが通るかだけ確認したいところです。
## 注意
protoxはGoogle公式やtonic公式からサポートを受けているソフトウェアではありません。現状活発にメンテナンスやサポートが行われているように見えますが、ひょっとしたらこれ原因で動かなくなる可能性があることに留意する必要があります。