### PR TITLE
usb-can-hardwareの抜けに対応

### DIFF
--- a/src/bin/usb_can_server.rs
+++ b/src/bin/usb_can_server.rs
@@ -123,7 +123,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
-    let server = UsbCanServer::new(Arc::clone(&handle));
+    let server = UsbCanServer::new(handle);
 
     let args: Vec<String> = env::args().collect();
     const DEFAULT_ADDRESS: &str = "127.0.0.1:50051";

--- a/src/bin/usb_can_server.rs
+++ b/src/bin/usb_can_server.rs
@@ -115,7 +115,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .product_id(PRODUCT_ID)
                 .register(&context, Box::new(HotPlugHandler::new(Arc::clone(&handle))))?,
         );
-        std::thread::spawn(move || {
+        tokio::task::spawn_blocking(move || {
+            // regの所有権をthreadに移している．
             let _reg = reg;
             loop {
                 context.handle_events(None).unwrap();

--- a/src/bin/usb_can_server.rs
+++ b/src/bin/usb_can_server.rs
@@ -3,15 +3,66 @@ pub mod pb {
 }
 
 use rusb::constants::{LIBUSB_ENDPOINT_IN, LIBUSB_ENDPOINT_OUT};
-use std::{env, time};
+use rusb::{Context, Device, HotplugBuilder, UsbContext};
+use std::{
+    env,
+    sync::{Arc, Mutex},
+    time,
+};
 use tonic::transport::Server;
+
+const VENDOR_ID: u16 = 0x483;
+const PRODUCT_ID: u16 = 0x5740;
+const B_INTERFACE_NUMBER: u8 = 1;
 
 const EP1: u8 = 1; // usb endpoint. use for implement usb_can_server::UsbCan trait.
 const TIMEOUT: time::Duration = time::Duration::from_millis(5000);
 
+struct HotPlugHandler {
+    handle: Arc<Mutex<Option<rusb::DeviceHandle<rusb::GlobalContext>>>>,
+}
+
+impl HotPlugHandler {
+    fn new(handle: Arc<Mutex<Option<rusb::DeviceHandle<rusb::GlobalContext>>>>) -> HotPlugHandler {
+        HotPlugHandler { handle }
+    }
+}
+
+impl<T: UsbContext> rusb::Hotplug<T> for HotPlugHandler {
+    fn device_arrived(&mut self, _: Device<T>) {
+        let mut locked_handle = self.handle.lock().unwrap();
+        if (locked_handle).is_some() {
+            let handle = rusb::open_device_with_vid_pid(VENDOR_ID, PRODUCT_ID).unwrap();
+            handle.set_auto_detach_kernel_driver(true).unwrap_or(());
+            handle.claim_interface(B_INTERFACE_NUMBER).unwrap();
+
+            *locked_handle = Some(handle);
+            println!("Device arrived");
+        }
+    }
+
+    fn device_left(&mut self, _: Device<T>) {
+        let mut locked_handle = self.handle.lock().unwrap();
+        *locked_handle = None;
+        println!("Device left");
+    }
+}
+
+impl Drop for HotPlugHandler {
+    fn drop(&mut self) {
+        println!("HotPlugHandler dropped");
+    }
+}
+
 #[derive(Debug)]
 pub struct UsbCanServer {
-    handle: rusb::DeviceHandle<rusb::GlobalContext>,
+    handle: Arc<Mutex<Option<rusb::DeviceHandle<rusb::GlobalContext>>>>,
+}
+
+impl UsbCanServer {
+    fn new(handle: Arc<Mutex<Option<rusb::DeviceHandle<rusb::GlobalContext>>>>) -> UsbCanServer {
+        UsbCanServer { handle }
+    }
 }
 
 #[tonic::async_trait]
@@ -21,9 +72,11 @@ impl pb::usb_can_server::UsbCan for UsbCanServer {
         _request: tonic::Request<pb::ReadRequest>,
     ) -> Result<tonic::Response<pb::ReadResponse>, tonic::Status> {
         let mut recv_buf = vec![0; _request.into_inner().size as usize];
-        self.handle
-            .read_bulk(LIBUSB_ENDPOINT_IN | EP1, &mut recv_buf, TIMEOUT)
-            .unwrap_or_default();
+        if let Some(ref handle) = *self.handle.lock().unwrap() {
+            handle
+                .read_bulk(LIBUSB_ENDPOINT_IN | EP1, &mut recv_buf, TIMEOUT)
+                .unwrap_or_default();
+        }
         Ok(tonic::Response::new(pb::ReadResponse {
             recv_buf: recv_buf,
         }))
@@ -33,10 +86,12 @@ impl pb::usb_can_server::UsbCan for UsbCanServer {
         _request: tonic::Request<pb::WriteRequest>,
     ) -> Result<tonic::Response<pb::WriteResponse>, tonic::Status> {
         let send_buf = _request.into_inner().send_buf;
-        let option = self
-            .handle
-            .write_bulk(LIBUSB_ENDPOINT_OUT | EP1, &send_buf, TIMEOUT)
-            .ok();
+        let option = match *self.handle.lock().unwrap() {
+            Some(ref handle) => handle
+                .write_bulk(LIBUSB_ENDPOINT_OUT | EP1, &send_buf, TIMEOUT)
+                .ok(),
+            None => None,
+        };
         Ok(tonic::Response::new(pb::WriteResponse {
             size: option.and_then(|size| size.try_into().ok()).unwrap_or(-1),
         }))
@@ -45,14 +100,34 @@ impl pb::usb_can_server::UsbCan for UsbCanServer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const VENDOR_ID: u16 = 0x483;
-    const PRODUCT_ID: u16 = 0x5740;
-    const B_INTERFACE_NUMBER: u8 = 1;
-    let handle = rusb::open_device_with_vid_pid(VENDOR_ID, PRODUCT_ID).unwrap();
-    handle.set_auto_detach_kernel_driver(true).unwrap_or(());
-    handle.claim_interface(B_INTERFACE_NUMBER).unwrap();
+    let handle = Arc::new(Mutex::new(Some(
+        rusb::open_device_with_vid_pid(VENDOR_ID, PRODUCT_ID).unwrap(),
+    )));
+    let locked_handle = handle.lock().unwrap();
+    if let Some(ref device_handle) = *locked_handle {
+        device_handle
+            .set_auto_detach_kernel_driver(true)
+            .unwrap_or(());
+        device_handle.claim_interface(B_INTERFACE_NUMBER).unwrap();
+    }
 
-    let server = UsbCanServer { handle };
+    if rusb::has_hotplug() {
+        let context = Context::new()?;
+        let _: Option<rusb::Registration<Context>> = Some(
+            HotplugBuilder::new()
+                .enumerate(true)
+                .vendor_id(VENDOR_ID)
+                .product_id(PRODUCT_ID)
+                .register(&context, Box::new(HotPlugHandler::new(Arc::clone(&handle))))?,
+        );
+        tokio::task::spawn_blocking(move || {
+            loop {
+                context.handle_events(None).unwrap();
+            }
+        });
+    }
+
+    let server = UsbCanServer::new(Arc::clone(&handle));
 
     let args: Vec<String> = env::args().collect();
     const DEFAULT_ADDRESS: &str = "127.0.0.1:50051";

--- a/src/bin/usb_can_server.rs
+++ b/src/bin/usb_can_server.rs
@@ -113,14 +113,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if rusb::has_hotplug() {
         let context = Context::new()?;
-        let _: Option<rusb::Registration<Context>> = Some(
+        let reg: Option<rusb::Registration<Context>> = Some(
             HotplugBuilder::new()
-                .enumerate(true)
+                .enumerate(false)
                 .vendor_id(VENDOR_ID)
                 .product_id(PRODUCT_ID)
                 .register(&context, Box::new(HotPlugHandler::new(Arc::clone(&handle))))?,
         );
         tokio::task::spawn_blocking(move || {
+            let _reg = reg;
             loop {
                 context.handle_events(None).unwrap();
             }


### PR DESCRIPTION
usb_can_hardwareが抜けたとき、刺しなおされたことを検出して`DeviceHandle`を握りなおす処理を追加しました．
これに伴って，`HotPlugHandler`と`UsbCanServer`という二つの構造体が`handle`のポインタを握らないといけなくなりました．
よって`handle`の型は`Arc<Mutex<T>>`でなくてはならなくなりました．
更に，usb_can_hardwareが抜けているという状態を考慮するために，handleは`Option<T>`でないといけなくなりました．
よって`Arc<Mutex<Option<DeviceHandle<GlobalContext>>>>`という地獄みたいな型が降臨爆誕しました．頭おかしい．

けっこう複雑な非同期Rustになりました．もしレビューされる方がいれば，lockが競合しないかどうかとかヘンなクラッシュが起こる可能性がないかなどに気を付けてレビューしていただけると嬉しいです．